### PR TITLE
Deprecation warning: …

### DIFF
--- a/vendor/assets/stylesheets/hint/_always.scss
+++ b/vendor/assets/stylesheets/hint/_always.scss
@@ -11,9 +11,9 @@
 // mixin to set margin on tooltip using translate transform
 @mixin set-margin($property, $transitionDirection) {
 	&:after, &:before {
-		-webkit-transform: #{$property}($transitionDirection * $transitionDistance);
-		-moz-transform: #{$property}($transitionDirection * $transitionDistance);
-		transform: #{$property}($transitionDirection * $transitionDistance);
+		-webkit-transform: unquote("#{$property}($transitionDirection * $transitionDistance);")
+		-moz-transform: unquote("#{$property}($transitionDirection * $transitionDistance);")
+		transform: unquote("#{$property}($transitionDirection * $transitionDistance);")
 	}
 }
 


### PR DESCRIPTION
#{} interpolation near operators will be simplified in a future version of Sass.

Using unquote method as it is indicated on the Deprecation Warning 
message.